### PR TITLE
Fix CI publish

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -57,6 +57,6 @@ jobs:
     - name: Store artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{github.event.repository.name}}
-        path: ${{github.workspace}}/*.zip
-        retention-days: 5
+        name: Android-CI-Build
+        path: ${{env.BUILD_DIR}}/*.zip
+        retention-days: 1

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -45,3 +45,16 @@ jobs:
       run: |
         ctest -C Release --output-on-failure
       shell: cmd
+
+    - name: Pack
+      working-directory: ${{env.BUILD_DIR}}
+      run: |
+        cpack
+      shell: cmd
+
+    - name: Store artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Windows-CI-Build
+        path: ${{env.BUILD_DIR}}/*.zip
+        retention-days: 1

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -43,6 +43,6 @@ jobs:
     - name: Store artifact
       uses: actions/upload-artifact@v4
       with:
-        name: ${{github.event.repository.name}}
-        path: ${{github.workspace}}/*.exe
+        name: Windows-Release-Build
+        path: ${{env.BUILD_DIR}}/*.exe
         retention-days: 5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ else ()
         enable_testing()
         add_subdirectory ( "tests" )
     endif ()
+    
+    install (
+        DIRECTORY   "resources"
+        DESTINATION "."
+    )
 endif ()
 
 set ( CPACK_GENERATOR "ZIP" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ else ()
     endif ()
     
     install (
-        DIRECTORY   "resources"
+        DIRECTORY   "assets"
         DESTINATION "."
     )
 endif ()

--- a/bin-windows/CMakeLists.txt
+++ b/bin-windows/CMakeLists.txt
@@ -6,3 +6,16 @@ set_target_properties ( ${PROJECT_NAME} PROPERTIES
 	VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
     WIN32_EXECUTABLE ON
 )
+
+# Packaging
+install (
+	FILES       "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/${THE_PROJECT_NAME}.exe"
+	DESTINATION "bin"
+)
+
+file ( GLOB DLLS "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/*.dll" )
+
+install (
+	FILES       ${DLLS}
+	DESTINATION "bin"
+)


### PR DESCRIPTION
* Fix all workflows so they look for cpack artifacts at a right place
* Add install rules for regular windows CI (NSIS will be added at a future date)