### PR TITLE
Feature: Cross platform sizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ cd _build
 cmake -D CMAKE_BUILD_SYSTEM=Android ..
 ```
 
-This will generate `bin-android/local.properties`, `bin-android/app/build.gradle.kts` and `bin-android/app/src/main/AppManifest.xml`. After that you can open the `_build` folder as a project in Android Studio and continue from there.
+After that you can open the `_build` folder as a project in Android Studio and continue from there. Or you can directly invoke Gradle and build from the command line:
 
 ```sh
-cmake --build . --target android-build
+gradlew build
 cpack
 ```

--- a/cmake/vars.cmake
+++ b/cmake/vars.cmake
@@ -2,12 +2,14 @@ set ( THE_PROJECT_NAME "Template" )
 set ( LIB_TARGET_NAME "game-lib" )
 set ( TEST_TARGET_NAME "unit-tests" )
 
+string ( TOLOWER "${THE_PROJECT_NAME}" PROJECT_NAME_LOWERCASE )
+
 # C++ vars
 set ( USE_SFML_TGUI_STATIC_LINKAGE OFF )
 set ( USE_PREBUILT_LIBRARIES OFF )
 
 # Android vars
-set ( ANDROID_ORG "org.nerudaj.template" )
+set ( ANDROID_ORG "org.nerudaj.${PROJECT_NAME_LOWERCASE}" )
 set ( ANDROID_NATIVE_LIB_NAME "cppcore" )
 set ( ANDROID_ARCH_ABI "arm64-v8a" )
 set ( ANDROID_NDK_VERSION "26.1.10909125" )

--- a/lib/include/gui/Sizers.hpp
+++ b/lib/include/gui/Sizers.hpp
@@ -1,21 +1,9 @@
 #pragma once
 
-class Sizers
+class Sizers final
 {
 public:
-    static unsigned GetSystemDPI();
+    [[nodiscard]] static unsigned getBaseFontSize();
 
-    static unsigned GetMenuBarHeight();
-
-    static unsigned GetMenuBarTextHeight();
-
-    static unsigned getBaseTextSize()
-    {
-        return GetMenuBarTextHeight();
-    }
-
-    static unsigned getBaseContainerHeight()
-    {
-        return GetMenuBarHeight();
-    }
+    [[nodiscard]] static unsigned getBaseContainerHeight();
 };

--- a/lib/include/jni/Core.hpp
+++ b/lib/include/jni/Core.hpp
@@ -2,13 +2,15 @@
 
 #ifdef ANDROID
 
+#include <jni/Jni.hpp>
+
 namespace jni
 {
 
 class Core
 {
 private:
-    Core(JavaVM* vm) : vm(vm) {}
+    Core(JavaVM* vm, JNIEnv* env) : vm(vm), env(env) {}
 
 public:
     Core(Core&& other) noexcept
@@ -23,10 +25,16 @@ public:
     }
 
 public:
-    static Core attachCurrentThread(JavaVM* vm, JNIEnv** env);
+    static Core attachCurrentThread();
+
+    [[nodiscard]] JNIEnv* getEnv()
+    {
+        return env;
+    }
 
 private:
     JavaVM* vm = nullptr;
+    JNIEnv* env = nullptr;
 };
 
 }

--- a/lib/include/jni/Core.hpp
+++ b/lib/include/jni/Core.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#ifdef ANDROID
+
+namespace jni
+{
+
+class Core
+{
+private:
+    Core(JavaVM* vm) : vm(vm) {}
+
+public:
+    Core(Core&& other) noexcept
+    {
+        std::swap(m_vm, other.m_vm);
+    }
+    Core(const Core&&) = delete;
+    ~Core()
+    {
+        if (m_vm)
+            m_vm->DetachCurrentThread();
+    }
+
+public:
+    static Core attachCurrentThread(JavaVM* vm, JNIEnv** env);
+
+private:
+    JavaVM* vm = nullptr;
+};
+
+}
+
+#endif

--- a/lib/include/jni/Core.hpp
+++ b/lib/include/jni/Core.hpp
@@ -15,13 +15,13 @@ private:
 public:
     Core(Core&& other) noexcept
     {
-        std::swap(m_vm, other.m_vm);
+        std::swap(vm, other.vm);
     }
     Core(const Core&&) = delete;
     ~Core()
     {
-        if (m_vm)
-            m_vm->DetachCurrentThread();
+        if (vm)
+            vm->DetachCurrentThread();
     }
 
 public:

--- a/lib/include/jni/DisplayMetrics.hpp
+++ b/lib/include/jni/DisplayMetrics.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#ifdef ANDROID
+
+#include <android/native_activity.h>
+
+namespace jni
+{
+
+class [[nodiscard]] DisplayMetrics final
+{
+private:
+    DisplayMetrics(JNIEnv* env, jobject displayMetrics) 
+        : env(env)
+        , displayMetrics(displayMetrics)
+    {
+        jclass metricsClass = env->FindClass("android/util/DisplayMetrics");
+        densityField = env->GetFieldID(metricsClass, "density", "F");
+    }
+
+public:
+    [[nodiscard]] float getDensity() const
+    {
+        return env->GetFloatField(displayMetrics, densityField);
+    }
+
+private:
+    JNIEnv* env;
+    jobject displayMetrics;
+    jfieldID densityField;
+};
+
+}
+
+#endif

--- a/lib/include/jni/DisplayMetrics.hpp
+++ b/lib/include/jni/DisplayMetrics.hpp
@@ -6,6 +6,7 @@
 
 namespace jni
 {
+class Resources;
 
 class [[nodiscard]] DisplayMetrics final
 {
@@ -17,6 +18,8 @@ private:
         jclass metricsClass = env->FindClass("android/util/DisplayMetrics");
         densityField = env->GetFieldID(metricsClass, "density", "F");
     }
+
+    friend class Resources;
 
 public:
     [[nodiscard]] float getDensity() const

--- a/lib/include/jni/Jni.hpp
+++ b/lib/include/jni/Jni.hpp
@@ -7,6 +7,6 @@
 #include <SFML/System/NativeActivity.hpp>
 #include <jni/Core.hpp>
 #include <jni/DisplayMetrics.hpp>
-#include <Resources.hpp>
+#include <jni/Resources.hpp>
 
 #endif

--- a/lib/include/jni/Jni.hpp
+++ b/lib/include/jni/Jni.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#ifdef ANDROID
+
+#include <android/native_activity.h>
+#include <jni.h>
+#include <SFML/System/NativeActivity.hpp>
+#include <jni/Core.hpp>
+#include <jni/DisplayMetrics.hpp>
+#include <Resources.hpp>
+
+#endif

--- a/lib/include/jni/Resources.hpp
+++ b/lib/include/jni/Resources.hpp
@@ -2,7 +2,7 @@
 
 #ifdef ANDROID
 
-#include <jni/JniDisplayMetrics.hpp>
+#include <jni/DisplayMetrics.hpp>
 
 #include <android/native_activity.h>
 
@@ -27,7 +27,7 @@ public:
 
     DisplayMetrics getDisplayMetrics() const
     {
-        return JniDisplayMetrics(
+        return DisplayMetrics(
             env,
             env->CallObjectMethod(resources, getDisplayMetricsMethod));
     }

--- a/lib/include/jni/Resources.hpp
+++ b/lib/include/jni/Resources.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#ifdef ANDROID
+
+#include <jni/JniDisplayMetrics.hpp>
+
+#include <android/native_activity.h>
+
+namespace jni
+{
+
+class [[nodiscard]] Resources final
+{
+private:
+    Resources(
+        JNIEnv* env,
+        jobject resources,
+        jmethodID getDisplayMetricsMethod)
+        : env(env)
+        , resources(resources)
+        , getDisplayMetricsMethod(getDisplayMetricsMethod)
+    {
+    }
+
+public:
+    static Resources getSystem(JNIEnv* env);
+
+    DisplayMetrics getDisplayMetrics() const
+    {
+        return JniDisplayMetrics(
+            env,
+            env->CallObjectMethod(resources, getDisplayMetricsMethod));
+    }
+
+private:
+    JNIEnv* env;
+    jobject resources;
+    jmethodID getDisplayMetricsMethod;
+};
+
+}
+
+#endif

--- a/lib/src/gui/Sizers.cpp
+++ b/lib/src/gui/Sizers.cpp
@@ -12,9 +12,9 @@ struct [[nodiscard]] BaseSizeProviderSingleton final
 private:
     BaseSizeProviderSingleton()
     {
-        auto core = jni::Core::attachCurrentThread(activity.vm, &activity.env);
+        auto core = jni::Core::attachCurrentThread();
         auto resources = jni::Resources::getSystem(core.getEnv());
-        pixelDensity = resources.GetDisplayMetrics().getDensity();
+        pixelDensity = resources.getDisplayMetrics().getDensity();
     }
 
 public:
@@ -22,7 +22,7 @@ public:
     BaseSizeProviderSingleton(const BaseSizeProviderSingleton&) = delete;
 
 public:
-    BaseSizeProviderSingleton& getInstance()
+    static BaseSizeProviderSingleton& getInstance()
     {
         static BaseSizeProviderSingleton instance;
         return instance;
@@ -39,7 +39,7 @@ public:
     }
 
 private:
-    unsigned spToPx(unsigned sp, float density)
+    static unsigned spToPx(unsigned sp, float density)
     {
         return static_cast<unsigned>(sp * density);
     }

--- a/lib/src/gui/Sizers.cpp
+++ b/lib/src/gui/Sizers.cpp
@@ -1,8 +1,12 @@
 #include "gui/Sizers.hpp"
 
+constexpr float CONTAINER_PADDING_MULTIPLIER = 2.55f;
+
 #ifdef ANDROID
 
 #include <jni/Jni.hpp>
+
+constexpr float ANDROID_BASE_UNSCALED_FONT_SIZE = 14;
 
 /**
  * Lazy-initialized base-size provider for Android.
@@ -30,12 +34,14 @@ public:
 
     [[nodiscard]] unsigned getBaseFontSize() const noexcept
     {
-        return spToPx(14, pixelDensity);
+        return spToPx(ANDROID_BASE_UNSCALED_FONT_SIZE, pixelDensity);
     }
 
     [[nodiscard]] unsigned getBaseContainerHeight() const noexcept
     {
-        return spToPx(22, pixelDensity);
+        return spToPx(
+            static_cast<unsigned>(ANDROID_BASE_UNSCALED_FONT_SIZE * CONTAINER_PADDING_MULTIPLIER),
+            pixelDensity);
     }
 
 private:
@@ -70,6 +76,6 @@ unsigned Sizers::getBaseContainerHeight()
 
 unsigned Sizers::getBaseFontSize()
 {
-    return static_cast<unsigned>(getBaseContainerHeight() / 2.55f);
+    return static_cast<unsigned>(getBaseContainerHeight() / CONTAINER_PADDING_MULTIPLIER);
 }
 #endif

--- a/lib/src/gui/builders/ButtonListBuilder.cpp
+++ b/lib/src/gui/builders/ButtonListBuilder.cpp
@@ -28,7 +28,7 @@ tgui::Panel::Ptr ButtonListBuilder::build()
     {
         auto&& button = WidgetBuilder::createButton(props.label, props.onClick);
         button->setSize({ "100%", Sizers::getBaseContainerHeight() * 1.5f });
-        button->setTextSize(Sizers::getBaseTextSize() * 2u);
+        button->setTextSize(Sizers::getBaseFontSize() * 2u);
         button->setPosition(
             { "0%", Sizers::getBaseContainerHeight() * idx * 2.1f });
         panel->add(button);

--- a/lib/src/gui/builders/FormBuilder.cpp
+++ b/lib/src/gui/builders/FormBuilder.cpp
@@ -79,7 +79,7 @@ static tgui::Label::Ptr createRowLabel(const std::string& text)
     label->getRenderer()->setTextColor(sf::Color::Black);
     label->setSize("60%", "100%");
     label->setPosition("0%", "0%");
-    label->setTextSize(Sizers::GetMenuBarTextHeight());
+    label->setTextSize(Sizers::getBaseFontSize());
     label->setVerticalAlignment(tgui::VerticalAlignment::Center);
     return label;
 }

--- a/lib/src/gui/builders/TableBuilder.cpp
+++ b/lib/src/gui/builders/TableBuilder.cpp
@@ -29,7 +29,7 @@ createCell(const std::string& str, size_t column, size_t totalColumns)
     label->setSize({ tgui::Layout(std::to_string(columnWidth) + "%"), "100%" });
     label->setPosition(
         { tgui::Layout(std::to_string(column * columnWidth) + "%"), "0%" });
-    label->setTextSize(Sizers::GetMenuBarTextHeight());
+    label->setTextSize(Sizers::getBaseFontSize());
     label->setHorizontalAlignment(tgui::HorizontalAlignment::Center);
     label->setVerticalAlignment(tgui::VerticalAlignment::Center);
     return label;

--- a/lib/src/gui/builders/WidgetBuilder.cpp
+++ b/lib/src/gui/builders/WidgetBuilder.cpp
@@ -28,7 +28,7 @@ tgui::Label::Ptr WidgetBuilder::createLabelInternal(
         justify ? tgui::HorizontalAlignment::Center
                 : tgui::HorizontalAlignment::Left);
     label->setTextSize(
-        static_cast<unsigned>(Sizers::getBaseTextSize() * sizeMultiplier));
+        static_cast<unsigned>(Sizers::getBaseFontSize() * sizeMultiplier));
     label->setSize({ "100%", "100%" });
     return label;
 }
@@ -45,7 +45,8 @@ WidgetBuilder::createPanel(const tgui::Layout2d& size, const tgui::Color color)
 tgui::Panel::Ptr WidgetBuilder::createRow(tgui::Color bgcolor)
 {
     auto&& row = tgui::Panel::create();
-    row->setSize("100%", std::to_string(Sizers::GetMenuBarHeight()).c_str());
+    row->setSize(
+        "100%", std::to_string(Sizers::getBaseContainerHeight()).c_str());
     row->getRenderer()->setBackgroundColor(bgcolor);
     return row;
 }
@@ -57,7 +58,7 @@ tgui::Button::Ptr WidgetBuilder::createButton(
 {
     auto&& button = tgui::Button::create(label);
     button->onClick(onClick);
-    button->setTextSize(Sizers::getBaseTextSize());
+    button->setTextSize(Sizers::getBaseFontSize());
     button->setSize({ "100%", "100%" });
 
     applyOptionsToWidget(options, button);
@@ -92,13 +93,13 @@ tgui::Panel::Ptr WidgetBuilder::createSlider(
 
     auto&& dummyLabel =
         tgui::Label::create(properties.valueFormatter(properties.high));
-    dummyLabel->setTextSize(Sizers::GetMenuBarTextHeight());
+    dummyLabel->setTextSize(Sizers::getBaseFontSize());
     dummyLabel->setAutoSize(true);
     gui.add(dummyLabel, "DummyLabel");
     auto size = dummyLabel->getSizeLayout();
 
     auto&& valueLabel = tgui::Label::create(properties.valueFormatter(value));
-    valueLabel->setTextSize(Sizers::GetMenuBarTextHeight());
+    valueLabel->setTextSize(Sizers::getBaseFontSize());
     valueLabel->getRenderer()->setTextColor(sf::Color::Black);
     valueLabel->setSize(size.x, "100%");
     valueLabel->setPosition("parent.width" - size.x, "0%");
@@ -173,7 +174,7 @@ tgui::Tabs::Ptr WidgetBuilder::createTabbedContent(
 {
     auto&& tabs = tgui::Tabs::create();
     tabs->setSize({ "100%", "100%" });
-    tabs->setTextSize(Sizers::getBaseTextSize());
+    tabs->setTextSize(Sizers::getBaseFontSize());
 
     for (auto&& label : tabLabels)
     {
@@ -201,7 +202,7 @@ tgui::Label::Ptr WidgetBuilder::createTooltip(const std::string& text)
     label->getRenderer()->setBackgroundColor(sf::Color::White);
     label->getRenderer()->setBorders(tgui::Outline(1u));
     label->getRenderer()->setBorderColor(sf::Color::Black);
-    label->setTextSize(Sizers::getBaseTextSize());
+    label->setTextSize(Sizers::getBaseFontSize());
     return label;
 }
 

--- a/lib/src/jni/Core.cpp
+++ b/lib/src/jni/Core.cpp
@@ -1,0 +1,22 @@
+#ifdef ANDROID
+
+#include <jni/Core.hpp>
+
+jni::Core jni::Core::attachCurrentThread(JavaVM* vm, JNIEnv** env)
+{
+    assert(vm && env);
+
+    JavaVMAttachArgs lJavaVMAttachArgs;
+    lJavaVMAttachArgs.version = JNI_VERSION_1_6;
+    lJavaVMAttachArgs.name = "NativeThread";
+    lJavaVMAttachArgs.group = nullptr;
+
+    jint lResult = vm->AttachCurrentThread(env, &lJavaVMAttachArgs);
+
+    if (lResult == JNI_ERR)
+        throw std::runtime_error("JNI: Could not attach current thread!");
+
+    return Core(vm);
+}
+
+#endif

--- a/lib/src/jni/Core.cpp
+++ b/lib/src/jni/Core.cpp
@@ -2,21 +2,22 @@
 
 #include <jni/Core.hpp>
 
-jni::Core jni::Core::attachCurrentThread(JavaVM* vm, JNIEnv** env)
+jni::Core jni::Core::attachCurrentThread()
 {
-    assert(vm && env);
+    auto& activity = *sf::getNativeActivity();
 
     JavaVMAttachArgs lJavaVMAttachArgs;
     lJavaVMAttachArgs.version = JNI_VERSION_1_6;
     lJavaVMAttachArgs.name = "NativeThread";
     lJavaVMAttachArgs.group = nullptr;
 
-    jint lResult = vm->AttachCurrentThread(env, &lJavaVMAttachArgs);
+    jint lResult = activity.vm->AttachCurrentThread(
+        &activity.env, &lJavaVMAttachArgs);
 
     if (lResult == JNI_ERR)
         throw std::runtime_error("JNI: Could not attach current thread!");
 
-    return Core(vm);
+    return Core(activity.vm, activity.env);
 }
 
 #endif

--- a/lib/src/jni/Core.cpp
+++ b/lib/src/jni/Core.cpp
@@ -6,18 +6,21 @@ jni::Core jni::Core::attachCurrentThread()
 {
     auto& activity = *sf::getNativeActivity();
 
+    JavaVM& vm  = *activity.vm;
+    JNIEnv* env = activity.env;
+
     JavaVMAttachArgs lJavaVMAttachArgs;
     lJavaVMAttachArgs.version = JNI_VERSION_1_6;
     lJavaVMAttachArgs.name = "NativeThread";
     lJavaVMAttachArgs.group = nullptr;
 
-    jint lResult = activity.vm->AttachCurrentThread(
-        &activity.env, &lJavaVMAttachArgs);
+    jint lResult = vm.AttachCurrentThread(
+        &env, &lJavaVMAttachArgs);
 
     if (lResult == JNI_ERR)
         throw std::runtime_error("JNI: Could not attach current thread!");
 
-    return Core(activity.vm, activity.env);
+    return Core(&vm, env);
 }
 
 #endif

--- a/lib/src/jni/Resources.cpp
+++ b/lib/src/jni/Resources.cpp
@@ -1,0 +1,14 @@
+#ifdef ANDROID
+
+#include <jni/Resources.hpp>
+
+jni::Resources jni::Resources::getSystem(JNIEnv* env)
+{
+    jclass resourcesClass = env->FindClass("android/content/res/Resources");
+    jmethodID getSystemMethod = env->GetStaticMethodID(resourcesClass, "getSystem", "()Landroid/content/res/Resources;");
+    jmethodID getDisplayMetricsMethod = env->GetMethodID(resourcesClass, "getDisplayMetrics", "()Landroid/util/DisplayMetrics;");
+    jobject resources = env->CallStaticObjectMethod(resourcesClass, getSystemMethod);
+    return Resources(env, resources, getDisplayMetricsMethod);
+}
+
+#endif


### PR DESCRIPTION
Sizers are now return sane values for both platforms. Added some JNI primitives for future expansion where needed. Sizers are technically singletons as passing them to GUI builders as dependencies would really mess up the builder API.

Scaling would have to be added here as well.

Tasks:
- [x] Test on Android