### PR TITLE
Feature: Configurable input

### DIFF
--- a/bin-android/Main.cpp
+++ b/bin-android/Main.cpp
@@ -26,7 +26,7 @@ int main(int, char*[])
             .useFullscreen = settings.video.fullscreen,
         });
         auto&& app = dgm::App(window);
-        auto&& dependencies = DependencyContainer(window, "", Language::English);
+        auto&& dependencies = DependencyContainer(window, "", Language::English, settings);
 
         window.getSfmlWindowContext().setMouseCursorVisible(false);
 

--- a/bin-windows/src/Main.cpp
+++ b/bin-windows/src/Main.cpp
@@ -27,8 +27,8 @@ int main(int, char*[])
             .useFullscreen = settings.video.fullscreen,
         });
         auto&& app = dgm::App(window);
-        auto&& dependencies =
-            DependencyContainer(window, "../assets", Language::English);
+        auto&& dependencies = DependencyContainer(
+            window, "../assets", Language::English, settings);
 
         window.getSfmlWindowContext().setMouseCursorVisible(false);
 

--- a/lib/include/appstate/AppStateOptions.hpp
+++ b/lib/include/appstate/AppStateOptions.hpp
@@ -50,6 +50,7 @@ private:
         auto btn = dic.gui.get<tgui::Button>(getBindButtonId<BindType>(action));
         btn->setText(HwInputToStringMapper {}.getMapping(newBinding));
         dic.input.updateBindings(settings.bindings);
+        dic.input.forceRelease(action);
     }
 
     template<class BindType>
@@ -63,6 +64,13 @@ private:
             return uni::format("BindButton_{}_KMB", std::to_underlying(action));
         else
             return uni::format("BindButton_{}_GMP", std::to_underlying(action));
+    }
+
+    template<class BindType>
+    void markButtonRebinding(InputKind action)
+    {
+        dic.gui.get<tgui::Button>(getBindButtonId<BindType>(action))
+            ->setText("...");
     }
 
 private:

--- a/lib/include/appstate/AppStateOptions.hpp
+++ b/lib/include/appstate/AppStateOptions.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "input/HwInputToStringMapper.hpp"
+#include "input/InputDetector.hpp"
 #include "misc/DependencyContainer.hpp"
 #include "settings/AppSettings.hpp"
 #include <DGM/dgm.hpp>
@@ -26,14 +28,46 @@ private:
 
     void buildInputOptionsLayout();
 
+    void buildBindingsOptionsLayout();
+
     void onTabClicked(const tgui::String& tabName);
 
     void onBack();
 
     void onResolutionSelected(const sf::Vector2u& resolution);
 
+    template<class BindType>
+#ifndef ANDROID
+        requires std::is_same_v<BindType, KmbBinding>
+                 || std::is_same_v<BindType, GamepadBinding>
+#endif
+    void onInputDetected(
+        InputKind action,
+        BindType newBinding,
+        std::map<InputKind, Binding>& target)
+    {
+        std::get<BindType>(target[action]) = newBinding;
+        auto btn = dic.gui.get<tgui::Button>(getBindButtonId<BindType>(action));
+        btn->setText(HwInputToStringMapper {}.getMapping(newBinding));
+        dic.input.updateBindings(settings.bindings);
+    }
+
+    template<class BindType>
+#ifndef ANDROID
+        requires std::is_same_v<BindType, KmbBinding>
+                 || std::is_same_v<BindType, GamepadBinding>
+#endif
+    static std::string getBindButtonId(InputKind action)
+    {
+        if constexpr (std::is_same_v<BindType, KmbBinding>)
+            return uni::format("BindButton_{}_KMB", std::to_underlying(action));
+        else
+            return uni::format("BindButton_{}_GMP", std::to_underlying(action));
+    }
+
 private:
     DependencyContainer& dic;
     AppSettings& settings;
     tgui::Panel::Ptr content;
+    InputDetector inputDetector;
 };

--- a/lib/include/appstate/AppStatePause.hpp
+++ b/lib/include/appstate/AppStatePause.hpp
@@ -9,7 +9,11 @@ class [[nodiscard]] AppStatePause final : public dgm::AppState
 public:
     AppStatePause(
         dgm::App& app, DependencyContainer& dic, AppSettings& settings) noexcept
-        : dgm::AppState(app, dgm::AppStateConfig {})
+        : dgm::AppState(
+              app,
+              dgm::AppStateConfig {
+                  .shouldDrawUnderlyingState = true,
+              })
         , dic(dic)
         , settings(settings)
     {

--- a/lib/include/appstate/CommonHandler.hpp
+++ b/lib/include/appstate/CommonHandler.hpp
@@ -17,4 +17,6 @@ public:
         DependencyContainer& dic,
         const InputSettings& settings,
         CommonHandlerOptions options = {});
+
+    static void swallowAllEvents(dgm::App& app);
 };

--- a/lib/include/enums/InputKind.hpp
+++ b/lib/include/enums/InputKind.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+enum class [[nodiscard]] InputKind
+{
+    BackButton,
+    ConfirmButton,
+    CursorUp,
+    CursorDown,
+    CursorLeft,
+    CursorRight,
+    MenuCycleLeft,
+    MenuCycleRight,
+    Left,
+    Right,
+    Jump,
+};

--- a/lib/include/enums/JoystickAxisPolarity.hpp
+++ b/lib/include/enums/JoystickAxisPolarity.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+enum class [[nodiscard]] JoystickAxisPolarity : bool
+{
+    Negative = 0,
+    Positive
+};

--- a/lib/include/enums/StringId.hpp
+++ b/lib/include/enums/StringId.hpp
@@ -9,16 +9,38 @@ enum class [[nodiscard]] StringId
     PauseTitle,
     ExitButton,
     Back,
+
+    // Options
     VideoOptionsTab,
     AudioOptionsTab,
     InputOptionsTab,
+    BindingsOptionsTab,
     EnableFullscreen,
     SetResolution,
     SoundVolume,
     MusicVolume,
     GamepadDeadzone,
     CursorSpeed,
+    BindingHeadingAction,
+    BindingHeadingKMB,
+    BindingsHeadingGamepad,
+
+    // InputKind
+    InputKind_BackButton,
+    InputKind_ConfirmButton,
+    InputKind_CursorUp,
+    InputKind_CursorDown,
+    InputKind_CursorLeft,
+    InputKind_CursorRight,
+    InputKind_MenuCycleLeft,
+    InputKind_MenuCycleRight,
+    InputKind_Left,
+    InputKind_Right,
+    InputKind_Jump,
+
+    // Pause
     Resume,
     BackToMenu,
+
     MaxId, // Make sure this one is always the last!
 };

--- a/lib/include/gui/builders/TableBuilder.hpp
+++ b/lib/include/gui/builders/TableBuilder.hpp
@@ -20,13 +20,15 @@ namespace priv
         {
         }
 
-        void addRow(const std::vector<std::string>& cells);
+        void addRow(const std::vector<tgui::Widget::Ptr>& cells);
+
+        void addSeparator();
 
         NODISCARD_RESULT tgui::Panel::Ptr build();
 
     private:
         std::optional<std::vector<std::string>> heading;
-        std::vector<std::vector<std::string>> rowsOfCells;
+        std::vector<std::vector<tgui::Widget::Ptr>> rowsOfCells;
     };
 } // namespace priv
 

--- a/lib/include/gui/builders/TableBuilder.hpp
+++ b/lib/include/gui/builders/TableBuilder.hpp
@@ -24,7 +24,7 @@ namespace priv
 
         void addSeparator();
 
-        NODISCARD_RESULT tgui::Panel::Ptr build();
+        NODISCARD_RESULT tgui::Widget::Ptr build();
 
     private:
         std::optional<std::vector<std::string>> heading;

--- a/lib/include/gui/builders/WidgetBuilder.hpp
+++ b/lib/include/gui/builders/WidgetBuilder.hpp
@@ -34,9 +34,9 @@ public:
 
 public:
     static NODISCARD_RESULT inline tgui::Label::Ptr
-    createTextLabel(const std::string& text)
+    createTextLabel(const std::string& text, bool justify = false)
     {
-        return createLabelInternal(text, 1.f);
+        return createLabelInternal(text, 1.f, justify);
     }
 
     static NODISCARD_RESULT inline tgui::Label::Ptr createHeading(
@@ -50,10 +50,19 @@ public:
         const tgui::Layout2d& size = { "100%", "100%" },
         const tgui::Color color = tgui::Color::Transparent);
 
+    static NODISCARD_RESULT tgui::ScrollablePanel::Ptr createScrollablePanel(
+        const tgui::Layout2d& size = { "100%", "100%" },
+        const tgui::Color color = tgui::Color::Transparent);
+
     static NODISCARD_RESULT tgui::Panel::Ptr
     createRow(tgui::Color bgcolor = tgui::Color::Transparent);
 
     static NODISCARD_RESULT tgui::Button::Ptr createButton(
+        const Label& label,
+        std::function<void(void)> onClick,
+        WidgetOptions options = WidgetOptions {});
+
+    static NODISCARD_RESULT tgui::Button::Ptr createSmallerButton(
         const Label& label,
         std::function<void(void)> onClick,
         WidgetOptions options = WidgetOptions {});

--- a/lib/include/input/HwInputToStringMapper.hpp
+++ b/lib/include/input/HwInputToStringMapper.hpp
@@ -78,7 +78,7 @@ public:
 
     NODISCARD_RESULT StringType operator()(auto)
     {
-        return "---";
+        return "<not bound>";
     }
 
     NODISCARD_RESULT StringType getMapping(KmbBinding binding)

--- a/lib/include/input/HwInputToStringMapper.hpp
+++ b/lib/include/input/HwInputToStringMapper.hpp
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "misc/Compatibility.hpp"
+#include "types/Binding.hpp"
+#include "types/SemanticTypes.hpp"
+#include "types/StringTypes.hpp"
+#include <DGM/dgm.hpp>
+#include <string>
+
+class HwInputToStringMapper
+{
+public:
+    NODISCARD_RESULT StringType operator()(sf::Keyboard::Key key)
+    {
+        if (sf::Keyboard::Key::A <= key && key <= sf::Keyboard::Key::Z)
+            return std::string(
+                1, static_cast<char>('A' + std::to_underlying(key)));
+        else if (key == sf::Keyboard::Key::Space)
+            return "Space";
+        else if (key == sf::Keyboard::Key::Enter)
+            return "Enter";
+        else if (key == sf::Keyboard::Key::Escape)
+            return "Escape";
+        else if (key == sf::Keyboard::Key::Tab)
+            return "Tab";
+        else if (key == sf::Keyboard::Key::Backspace)
+            return "Backspace";
+        return uni::format("key {}", std::to_underlying(key));
+    }
+
+    NODISCARD_RESULT StringType operator()(sf::Mouse::Button btn)
+    {
+        if (btn == sf::Mouse::Button::Left)
+            return "LMB";
+        else if (btn == sf::Mouse::Button::Right)
+            return "RMB";
+        return uni::format("mouse {}", std::to_underlying(btn));
+    }
+
+    NODISCARD_RESULT StringType operator()(GamepadButton gamepadButtonIndex)
+    {
+        return uni::format("joy {}", gamepadButtonIndex.get());
+    }
+
+    NODISCARD_RESULT StringType
+    operator()(std::pair<sf::Joystick::Axis, dgm::AxisHalf> axis)
+    {
+        auto axisName = [](sf::Joystick::Axis a) -> std::string
+        {
+            switch (a)
+            {
+            case sf::Joystick::Axis::X:
+                return "X";
+            case sf::Joystick::Axis::Y:
+                return "Y";
+            case sf::Joystick::Axis::Z:
+                return "Z";
+            case sf::Joystick::Axis::R:
+                return "R";
+            case sf::Joystick::Axis::U:
+                return "U";
+            case sf::Joystick::Axis::V:
+                return "V";
+            case sf::Joystick::Axis::PovX:
+                return "PovX";
+            case sf::Joystick::Axis::PovY:
+                return "PovY";
+            };
+
+            return uni::format("Axis {}", std::to_underlying(a));
+        };
+
+        return uni::format(
+            "{}{}",
+            axisName(axis.first),
+            axis.second == dgm::AxisHalf::Negative ? "-" : "+");
+    }
+
+    NODISCARD_RESULT StringType operator()(auto)
+    {
+        return "---";
+    }
+
+    NODISCARD_RESULT StringType getMapping(KmbBinding binding)
+    {
+        return std::visit(*this, binding);
+    }
+
+    NODISCARD_RESULT StringType getMapping(GamepadBinding binding)
+    {
+        return std::visit(*this, binding);
+    }
+};

--- a/lib/include/input/Input.hpp
+++ b/lib/include/input/Input.hpp
@@ -1,31 +1,31 @@
 #pragma once
 
+#include "enums/InputKind.hpp"
 #include "misc/Compatibility.hpp"
+#include "settings/BindingsSettings.hpp"
 #include <DGM/dgm.hpp>
-
-enum class [[nodiscard]] InputKind
-{
-    BackButton,
-    ConfirmButton,
-    CursorUp,
-    CursorDown,
-    CursorLeft,
-    CursorRight,
-    MenuCycleLeft,
-    MenuCycleRight,
-    Left,
-    Right,
-    Jump,
-};
 
 class [[nodiscard]] Input final
 {
 public:
-    Input();
+    Input(const BindingsSettings& settings)
+        : controller(configureController(settings))
+    {
+    }
+
     Input(Input&&) = delete;
     Input(const Input&) = delete;
 
 public:
+    void updateBindings(const BindingsSettings& settings);
+
+    /// <summary>
+    /// This is used in options to make sure that a configured
+    /// key for confirm/back doesn't immediately mess up with
+    /// the app.
+    /// </summary>
+    void forceRelease(InputKind action);
+
 #pragma region For dummy entity, can be removed
     float getHorizontalVelocity() const;
 
@@ -44,6 +44,9 @@ public:
 
 private:
     bool readAndRelease(InputKind i) const;
+
+    static dgm::Controller<InputKind>
+    configureController(const BindingsSettings& settings);
 
 private:
     mutable dgm::Controller<InputKind> controller;

--- a/lib/include/input/InputDetector.hpp
+++ b/lib/include/input/InputDetector.hpp
@@ -31,6 +31,11 @@ public:
 
     void update(const dgm::Time& time);
 
+    bool isDetectionInProgress() const
+    {
+        return runMode != RunMode::Idle;
+    }
+
 private:
     enum class [[nodiscard]] RunMode
     {

--- a/lib/include/input/InputDetector.hpp
+++ b/lib/include/input/InputDetector.hpp
@@ -31,7 +31,7 @@ public:
 
     void update(const dgm::Time& time);
 
-    bool isDetectionInProgress() const
+    NODISCARD_RESULT bool isDetectionInProgress() const noexcept
     {
         return runMode != RunMode::Idle;
     }

--- a/lib/include/input/InputDetector.hpp
+++ b/lib/include/input/InputDetector.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "types/Binding.hpp"
+#include <functional>
+
+class [[nodiscard]] InputDetector final
+{
+public:
+    using ReportKmbCallbackType = std::function<void(KmbBinding)>;
+    using ReportGamepadCallbackType = std::function<void(GamepadBinding)>;
+    using CancelCallbackType = std::function<void()>;
+
+    void startCheckingInputs(
+        ReportKmbCallbackType reportCallback, CancelCallbackType cancelCallback)
+    {
+        reportKmb = reportCallback;
+        cancel = cancelCallback;
+        runMode = RunMode::DetectingKmb;
+        initialDelay = sf::seconds(1.f).asSeconds();
+    }
+
+    void startCheckingInputs(
+        ReportGamepadCallbackType reportCallback,
+        CancelCallbackType cancelCallback)
+    {
+        reportGamepad = reportCallback;
+        cancel = cancelCallback;
+        runMode = RunMode::DetectingGamepad;
+        initialDelay = sf::seconds(1.f).asSeconds();
+    }
+
+    void update(const dgm::Time& time);
+
+private:
+    enum class [[nodiscard]] RunMode
+    {
+        Idle,
+        DetectingKmb,
+        DetectingGamepad,
+    };
+
+    enum class [[nodiscard]] DetectionStatus
+    {
+        None,
+        InputDetected
+    };
+
+    DetectionStatus tryGamepadAxis();
+
+    DetectionStatus tryGamepadButton();
+
+    DetectionStatus tryKeyboard();
+
+    DetectionStatus tryMouse();
+
+private:
+    RunMode runMode = RunMode::Idle;
+    ReportKmbCallbackType reportKmb;
+    ReportGamepadCallbackType reportGamepad;
+    CancelCallbackType cancel;
+    float initialDelay = 0;
+};

--- a/lib/include/input/InputKindToStringMapper.hpp
+++ b/lib/include/input/InputKindToStringMapper.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "enums/InputKind.hpp"
+#include "enums/StringId.hpp"
+#include "misc/StringProvider.hpp"
+
+class [[nodiscard]] InputKindToStringMapper final
+{
+public:
+    InputKindToStringMapper(const StringProvider& strings) : strings(strings) {}
+
+    InputKindToStringMapper(InputKindToStringMapper&&) = delete;
+    InputKindToStringMapper(const InputKindToStringMapper&) = delete;
+
+public:
+    const CharType* inputKindToString(InputKind kind)
+    {
+        switch (kind)
+        {
+        case InputKind::BackButton:
+            return strings.getString(StringId::InputKind_BackButton);
+        case InputKind::ConfirmButton:
+            return strings.getString(StringId::InputKind_ConfirmButton);
+        case InputKind::CursorUp:
+            return strings.getString(StringId::InputKind_CursorUp);
+        case InputKind::CursorDown:
+            return strings.getString(StringId::InputKind_CursorDown);
+        case InputKind::CursorLeft:
+            return strings.getString(StringId::InputKind_CursorLeft);
+        case InputKind::CursorRight:
+            return strings.getString(StringId::InputKind_CursorRight);
+        case InputKind::MenuCycleLeft:
+            return strings.getString(StringId::InputKind_MenuCycleLeft);
+        case InputKind::MenuCycleRight:
+            return strings.getString(StringId::InputKind_MenuCycleRight);
+        case InputKind::Left:
+            return strings.getString(StringId::InputKind_Left);
+        case InputKind::Right:
+            return strings.getString(StringId::InputKind_Right);
+        case InputKind::Jump:
+            return strings.getString(StringId::InputKind_Jump);
+        default:
+            return "--error--";
+        }
+    }
+
+private:
+    const StringProvider& strings;
+};

--- a/lib/include/misc/DependencyContainer.hpp
+++ b/lib/include/misc/DependencyContainer.hpp
@@ -5,6 +5,7 @@
 #include "input/VirtualCursor.hpp"
 #include "misc/ResourceLoader.hpp"
 #include "misc/StringProvider.hpp"
+#include "settings/AppSettings.hpp"
 #include <DGM/dgm.hpp>
 
 struct [[nodiscard]] DependencyContainer final
@@ -18,14 +19,15 @@ struct [[nodiscard]] DependencyContainer final
     DependencyContainer(
         dgm::Window& window,
         const std::filesystem::path& rootDir,
-        Language primaryLang)
+        Language primaryLang,
+        const AppSettings& settings)
         // Gui needs to be instantiated before Resource manager
         // since we need to have gui backend defined before
         // other tgui objects (like fonts) can be created.
         : gui(window)
         , resmgr(ResourceLoader::loadResources(rootDir))
         , strings(primaryLang)
-        , input()
+        , input(settings.bindings)
         , virtualCursor(
               window.getSfmlWindowContext(),
               input,

--- a/lib/include/misc/StringProvider.hpp
+++ b/lib/include/misc/StringProvider.hpp
@@ -3,8 +3,8 @@
 #include "enums/Language.hpp"
 #include "types/StringTypes.hpp"
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 class [[nodiscard]] StringProvider final
 {
@@ -22,8 +22,10 @@ public:
 
     constexpr const CharType* getString(StringId id) const noexcept
     {
-        return strings[std::to_underlying(current)][std::to_underlying(id)]
-            .data();
+        const auto result =
+            strings[std::to_underlying(current)][std::to_underlying(id)].data();
+        if (!result) return "--missing string--";
+        return result;
     }
 
 private:

--- a/lib/include/settings/AppSettings.hpp
+++ b/lib/include/settings/AppSettings.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "settings/AudioSettings.hpp"
+#include "settings/BindingsSettings.hpp"
 #include "settings/InputSettings.hpp"
 #include "settings/VideoSettings.hpp"
 
@@ -9,4 +10,5 @@ struct [[nodiscard]] AppSettings final
     AudioSettings audio;
     VideoSettings video;
     InputSettings input;
+    BindingsSettings bindings;
 };

--- a/lib/include/settings/BindingsSettings.hpp
+++ b/lib/include/settings/BindingsSettings.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "enums/InputKind.hpp"
+#include "types/Binding.hpp"
+#include <map>
+
+struct [[nodiscard]] BindingsSettings final
+{
+    std::map<InputKind, Binding> ingameBindings = {
+        { InputKind::Left,
+          Binding {
+              sf::Keyboard::Key::A,
+              std::pair { sf::Joystick::Axis::X, dgm::AxisHalf::Negative } } },
+        { InputKind::Right,
+          Binding {
+              sf::Keyboard::Key::D,
+              std::pair { sf::Joystick::Axis::X, dgm::AxisHalf::Positive } } },
+        { InputKind::Jump,
+          Binding { sf::Keyboard::Key::Space, GamepadButton { 0 } } },
+    };
+
+    std::map<InputKind, Binding> menuBindings = {
+        { InputKind::BackButton,
+          { sf::Keyboard::Key::Escape, GamepadButton { 6 } } },
+        { InputKind::ConfirmButton,
+          { std::monostate {}, GamepadButton { 0 } } },
+        { InputKind::CursorUp,
+          { std::monostate {},
+            std::pair { sf::Joystick::Axis::Y, dgm::AxisHalf::Negative } } },
+        { InputKind::CursorDown,
+          { std::monostate {},
+            std::pair { sf::Joystick::Axis::Y, dgm::AxisHalf::Positive } } },
+        { InputKind::CursorLeft,
+          { std::monostate {},
+            std::pair { sf::Joystick::Axis::X, dgm::AxisHalf::Negative } } },
+        { InputKind::CursorRight,
+          { std::monostate {},
+            std::pair { sf::Joystick::Axis::X, dgm::AxisHalf::Positive } } },
+        { InputKind::MenuCycleLeft,
+          { std::monostate {}, GamepadButton { 4 } } },
+        { InputKind::MenuCycleRight,
+          { std::monostate {}, GamepadButton { 5 } } },
+    };
+};

--- a/lib/include/settings/InputSettings.hpp
+++ b/lib/include/settings/InputSettings.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <types/SemanticTypes.hpp>
+
 struct [[nodiscard]] InputSettings final
 {
-    float cursorSpeed = 500.f; // TODO: migrate to pxpersecond
+    float cursorSpeed = 500_px_per_second;
     float gamepadDeadzone = 10.f;
 };

--- a/lib/include/types/Binding.hpp
+++ b/lib/include/types/Binding.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "types/SemanticTypes.hpp"
+#include <DGM/dgm.hpp>
+#include <tuple>
+#include <variant>
+
+using KmbBinding =
+    std::variant<sf::Keyboard::Key, sf::Mouse::Button, std::monostate>;
+
+using GamepadBinding = std::variant<
+    GamepadButton,
+    std::pair<sf::Joystick::Axis, dgm::AxisHalf>,
+    std::monostate>;
+
+using Binding = std::tuple<KmbBinding, GamepadBinding>;
+
+static_assert(std::is_default_constructible_v<KmbBinding>);
+static_assert(std::is_default_constructible_v<GamepadBinding>);
+static_assert(std::is_default_constructible_v<Binding>);

--- a/lib/include/types/BrandedType.hpp
+++ b/lib/include/types/BrandedType.hpp
@@ -4,6 +4,11 @@ template<class T, class Parameter>
 class BrandedType
 {
 public:
+    template<class = std::enable_if<std::is_default_constructible_v<T>>>
+    BrandedType() : value(T {})
+    {
+    }
+
     explicit constexpr BrandedType(const T& value) : value(value) {}
 
     explicit constexpr BrandedType(T&& value) : value(std::move(value)) {}

--- a/lib/include/types/BrandedType.hpp
+++ b/lib/include/types/BrandedType.hpp
@@ -13,10 +13,22 @@ public:
 
     explicit constexpr BrandedType(T&& value) : value(std::move(value)) {}
 
-    constexpr auto&& get(this auto&& self)
+#ifdef ANDROID
+    constexpr const T& get() const noexcept
+    {
+        return value;
+    }
+
+    constexpr T& get() noexcept
+    {
+        return value;
+    }
+#else
+    constexpr auto&& get(this auto&& self) noexcept
     {
         return self.value;
     }
+#endif
 
 private:
     T value;

--- a/lib/include/types/Overloads.hpp
+++ b/lib/include/types/Overloads.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+template<class... Ts>
+struct overloads : Ts...
+{
+    using Ts::operator()...;
+};
+
+#ifdef ANDROID
+
+// Deduction guide not needed since C++20
+template<class... Ts>
+overloads(Ts...) -> overloads<Ts...>;
+
+#endif

--- a/lib/include/types/SemanticTypes.hpp
+++ b/lib/include/types/SemanticTypes.hpp
@@ -5,6 +5,7 @@
 
 using Direction = BrandedType<sf::Vector2f, struct DirectionTypeTag>;
 using Position = BrandedType<sf::Vector2f, struct PositionTypeTag>;
+using GamepadButton = BrandedType<unsigned, struct GamepadButtonTag>;
 
 consteval float operator""_px_per_second(unsigned long long value)
 {

--- a/lib/include/types/StringTypes.hpp
+++ b/lib/include/types/StringTypes.hpp
@@ -5,5 +5,6 @@
 #include <string>
 
 using CharType = char;
-using StringView = std::basic_string_view<CharType>;
-using Localization = std::map<StringId, StringView>;
+using StringType = std::basic_string<CharType>;
+using StringViewType = std::basic_string_view<CharType>;
+using Localization = std::map<StringId, StringViewType>;

--- a/lib/private_include/localization/EnLocalization.hpp
+++ b/lib/private_include/localization/EnLocalization.hpp
@@ -5,21 +5,42 @@
 
 using enum StringId;
 
-const std::map<StringId, StringView> EN_LOCALIZATION = {
+const std::map<StringId, StringViewType> EN_LOCALIZATION = {
     { PlayButton, "Play" },
     { Options, "Options" },
     { PauseTitle, "Game paused" },
     { ExitButton, "Exit" },
     { Back, "Back" },
+
+    // Options
     { VideoOptionsTab, "Video" },
     { AudioOptionsTab, "Audio" },
     { InputOptionsTab, "Input" },
+    { BindingsOptionsTab, "Bindings" },
     { EnableFullscreen, "Fullscreen" },
     { SetResolution, "Resolution" },
     { SoundVolume, "Sound volume" },
     { MusicVolume, "Music volume" },
     { GamepadDeadzone, "Gamepad deadzone" },
     { CursorSpeed, "Cursor speed" },
+    { BindingHeadingAction, "Action" },
+    { BindingHeadingKMB, "Keyboard/Mouse" },
+    { BindingsHeadingGamepad, "Gamepad" },
+
+    // InputKind
+    { InputKind_BackButton, "Back" },
+    { InputKind_ConfirmButton, "Confirm" },
+    { InputKind_CursorUp, "Cursor up" },
+    { InputKind_CursorDown, "Cursor down" },
+    { InputKind_CursorLeft, "Cursor left" },
+    { InputKind_CursorRight, "Cursor right" },
+    { InputKind_MenuCycleLeft, "Menu cycle left" },
+    { InputKind_MenuCycleRight, "Menu cycle right" },
+    { InputKind_Left, "Run left" },
+    { InputKind_Right, "Run right" },
+    { InputKind_Jump, "Jump" },
+
+    // Pause
     { Resume, "Resume game" },
     { BackToMenu, "Back to main menu" },
 };

--- a/lib/src/appstate/AppStateOptions.cpp
+++ b/lib/src/appstate/AppStateOptions.cpp
@@ -40,6 +40,13 @@ AppStateOptions::AppStateOptions(
 
 void AppStateOptions::input()
 {
+    if (inputDetector.isDetectionInProgress())
+    {
+        inputDetector.update(app.time);
+        CommonHandler::swallowAllEvents(app);
+        return;
+    }
+
     CommonHandler::handleInput(app, dic, settings.input);
 
     auto tabs = dic.gui.get<tgui::Tabs>(TABS_ID);
@@ -53,8 +60,6 @@ void AppStateOptions::input()
     {
         tabs->select((tabs->getSelectedIndex() + 1) % tabs->getTabsCount());
     }
-
-    inputDetector.update(app.time);
 }
 
 void AppStateOptions::update() {}
@@ -227,6 +232,7 @@ void AppStateOptions::buildBindingsOptionsLayout()
                         std::visit(hwInputMapper, kmbBinding),
                         [&]()
                         {
+                            markButtonRebinding<KmbBinding>(action);
                             inputDetector.startCheckingInputs(
                                 [&](KmbBinding b)
                                 { onInputDetected(action, b, bindings); },
@@ -245,6 +251,7 @@ void AppStateOptions::buildBindingsOptionsLayout()
                         std::visit(hwInputMapper, gamepadBinding),
                         [&]()
                         {
+                            markButtonRebinding<GamepadBinding>(action);
                             inputDetector.startCheckingInputs(
                                 [&](GamepadBinding b)
                                 { onInputDetected(action, b, bindings); },

--- a/lib/src/appstate/AppStateOptions.cpp
+++ b/lib/src/appstate/AppStateOptions.cpp
@@ -1,7 +1,9 @@
 #include "appstate/AppStateOptions.hpp"
 #include "appstate/CommonHandler.hpp"
 #include "gui/Builders.hpp"
+#include "input/InputKindToStringMapper.hpp"
 #include "misc/Compatibility.hpp"
+#include "types/Overloads.hpp"
 #include <ranges>
 
 const tgui::Color CONTENT_BGCOLOR = tgui::Color(255, 255, 255, 64);
@@ -31,7 +33,7 @@ AppStateOptions::AppStateOptions(
     : dgm::AppState(app)
     , dic(dic)
     , settings(settings)
-    , content(WidgetBuilder::createPanel())
+    , content(WidgetBuilder::createScrollablePanel())
 {
     buildLayout();
 }
@@ -51,6 +53,8 @@ void AppStateOptions::input()
     {
         tabs->select((tabs->getSelectedIndex() + 1) % tabs->getTabsCount());
     }
+
+    inputDetector.update(app.time);
 }
 
 void AppStateOptions::update() {}
@@ -75,6 +79,7 @@ void AppStateOptions::buildLayout()
                             dic.strings.getString(StringId::VideoOptionsTab),
                             dic.strings.getString(StringId::AudioOptionsTab),
                             dic.strings.getString(StringId::InputOptionsTab),
+                            dic.strings.getString(StringId::BindingsOptionsTab),
                         },
                         [&](const tgui::String& tabName)
                         { onTabClicked(tabName); },
@@ -87,8 +92,6 @@ void AppStateOptions::buildLayout()
                 dic.strings.getString(StringId::Back), [&] { onBack(); }))
             .withNoSubmitButton()
             .build());
-
-    // TODO: configure controls
 
     buildVideoOptionsLayout();
 }
@@ -178,6 +181,95 @@ void AppStateOptions::buildInputOptionsLayout()
             .build(CONTENT_BGCOLOR));
 }
 
+template<class V, class T>
+bool doesVariantContain(const V& v, T t)
+{
+    if (std::holds_alternative<T>(v)) return std::get<T>(v) == t;
+    return false;
+}
+
+void AppStateOptions::buildBindingsOptionsLayout()
+{
+    auto&& inputKindMapper = InputKindToStringMapper(dic.strings);
+    auto&& hwInputMapper = HwInputToStringMapper();
+
+    auto tableBuilder = TableBuilder().withHeading({
+        dic.strings.getString(StringId::BindingHeadingAction),
+        dic.strings.getString(StringId::BindingHeadingKMB),
+        dic.strings.getString(StringId::BindingsHeadingGamepad),
+    });
+
+    auto buttonOrNothing = [](tgui::Button::Ptr ptr,
+                              bool useNothing) -> tgui::Widget::Ptr
+    {
+        if (useNothing) WidgetBuilder::createTextLabel("");
+        return ptr;
+    };
+
+    auto addSectionToTable = [&](std::map<InputKind, Binding>& bindings)
+    {
+        for (auto&& [action, binding] : bindings)
+        {
+            auto&& [kmbBinding, gamepadBinding] = binding;
+
+            const bool isEscapeKey =
+                doesVariantContain(kmbBinding, sf::Keyboard::Key::Escape);
+            const bool noKmb =
+                doesVariantContain(kmbBinding, std::monostate {});
+            const bool noGmp =
+                doesVariantContain(gamepadBinding, std::monostate {});
+
+            tableBuilder.addRow({
+                WidgetBuilder::createTextLabel(
+                    inputKindMapper.inputKindToString(action)),
+                buttonOrNothing(
+                    WidgetBuilder::createSmallerButton(
+                        std::visit(hwInputMapper, kmbBinding),
+                        [&]()
+                        {
+                            inputDetector.startCheckingInputs(
+                                [&](KmbBinding b)
+                                { onInputDetected(action, b, bindings); },
+                                [&]()
+                                {
+                                    onInputDetected(
+                                        action, kmbBinding, bindings);
+                                });
+                        },
+                        WidgetOptions { .id =
+                                            getBindButtonId<KmbBinding>(action),
+                                        .enabled = !isEscapeKey }),
+                    noKmb),
+                buttonOrNothing(
+                    WidgetBuilder::createSmallerButton(
+                        std::visit(hwInputMapper, gamepadBinding),
+                        [&]()
+                        {
+                            inputDetector.startCheckingInputs(
+                                [&](GamepadBinding b)
+                                { onInputDetected(action, b, bindings); },
+                                [&]()
+                                {
+                                    onInputDetected(
+                                        action, gamepadBinding, bindings);
+                                });
+                        },
+                        WidgetOptions {
+                            .id = getBindButtonId<GamepadBinding>(action),
+                        }),
+                    noGmp),
+            });
+        }
+    };
+
+    addSectionToTable(settings.bindings.ingameBindings);
+    tableBuilder.addSeparator();
+    addSectionToTable(settings.bindings.menuBindings);
+
+    content->removeAllWidgets();
+    content->add(tableBuilder.build());
+}
+
 void AppStateOptions::onTabClicked(const tgui::String& tabName)
 {
     if (tabName == dic.strings.getString(StringId::VideoOptionsTab))
@@ -186,6 +278,8 @@ void AppStateOptions::onTabClicked(const tgui::String& tabName)
         buildAudioOptionsLayout();
     else if (tabName == dic.strings.getString(StringId::InputOptionsTab))
         buildInputOptionsLayout();
+    else if (tabName == dic.strings.getString(StringId::BindingsOptionsTab))
+        buildBindingsOptionsLayout();
 }
 
 void AppStateOptions::onBack()

--- a/lib/src/appstate/CommonHandler.cpp
+++ b/lib/src/appstate/CommonHandler.cpp
@@ -27,3 +27,11 @@ void CommonHandler::handleInput(
         app.popState();
     }
 }
+
+void CommonHandler::swallowAllEvents(dgm::App& app)
+{
+    while (const auto event = app.window.pollEvent())
+    {
+        if (event->is<sf::Event::Closed>()) app.exit();
+    }
+}

--- a/lib/src/gui/builders/FormBuilder.cpp
+++ b/lib/src/gui/builders/FormBuilder.cpp
@@ -73,24 +73,13 @@ tgui::Panel::Ptr FormBuilder::build(tgui::Color backgroundColor)
     return panel;
 }
 
-static tgui::Label::Ptr createRowLabel(const std::string& text)
-{
-    auto&& label = tgui::Label::create(text);
-    label->getRenderer()->setTextColor(sf::Color::Black);
-    label->setSize("60%", "100%");
-    label->setPosition("0%", "0%");
-    label->setTextSize(Sizers::getBaseFontSize());
-    label->setVerticalAlignment(tgui::VerticalAlignment::Center);
-    return label;
-}
-
 tgui::Panel::Ptr FormBuilder::createOptionRow(
     const std::string& labelText,
     tgui::Widget::Ptr widgetPtr,
     std::optional<std::string> widgetId)
 {
     auto&& row = WidgetBuilder::createRow();
-    row->add(createRowLabel(labelText));
+    row->add(WidgetBuilder::createTextLabel(labelText));
 
     auto&& widgetPanel = tgui::Panel::create({ "40%", "100%" });
     widgetPanel->setPosition("60%", "0%");
@@ -120,7 +109,7 @@ tgui::Panel::Ptr FormBuilder::createOptionRowWithSubmitButton(
     tgui::Button::Ptr buttonPtr)
 {
     auto&& row = WidgetBuilder::createRow();
-    row->add(createRowLabel(labelText));
+    row->add(WidgetBuilder::createTextLabel(labelText));
 
     auto&& widgetPanel = tgui::Panel::create({ "25%", "100%" });
     widgetPanel->setPosition("60%", "0%");

--- a/lib/src/gui/builders/TableBuilder.cpp
+++ b/lib/src/gui/builders/TableBuilder.cpp
@@ -39,9 +39,9 @@ createCell(const tgui::Widget::Ptr& content, size_t column, size_t totalColumns)
     return cell;
 }
 
-tgui::Panel::Ptr priv::TableBuilder::build()
+tgui::Widget::Ptr priv::TableBuilder::build()
 {
-    auto&& panel = WidgetBuilder::createPanel();
+    auto&& panel = WidgetBuilder::createScrollablePanel();
 
     assert(heading || !rowsOfCells.empty());
 

--- a/lib/src/gui/builders/WidgetBuilder.cpp
+++ b/lib/src/gui/builders/WidgetBuilder.cpp
@@ -48,7 +48,6 @@ tgui::ScrollablePanel::Ptr WidgetBuilder::createScrollablePanel(
     auto&& panel = tgui::ScrollablePanel::create(size);
     panel->setPosition({ "0%", "0%" });
     panel->getRenderer()->setBackgroundColor(color);
-    panel->getVerticalScrollbar()->setPolicy(tgui::Scrollbar::Policy::Always);
     return panel;
 }
 

--- a/lib/src/gui/builders/WidgetBuilder.cpp
+++ b/lib/src/gui/builders/WidgetBuilder.cpp
@@ -42,6 +42,16 @@ WidgetBuilder::createPanel(const tgui::Layout2d& size, const tgui::Color color)
     return panel;
 }
 
+tgui::ScrollablePanel::Ptr WidgetBuilder::createScrollablePanel(
+    const tgui::Layout2d& size, const tgui::Color color)
+{
+    auto&& panel = tgui::ScrollablePanel::create(size);
+    panel->setPosition({ "0%", "0%" });
+    panel->getRenderer()->setBackgroundColor(color);
+    panel->getVerticalScrollbar()->setPolicy(tgui::Scrollbar::Policy::Always);
+    return panel;
+}
+
 tgui::Panel::Ptr WidgetBuilder::createRow(tgui::Color bgcolor)
 {
     auto&& row = tgui::Panel::create();
@@ -60,6 +70,24 @@ tgui::Button::Ptr WidgetBuilder::createButton(
     button->onClick(onClick);
     button->setTextSize(Sizers::getBaseFontSize());
     button->setSize({ "100%", "100%" });
+
+    applyOptionsToWidget(options, button);
+
+    return button;
+}
+
+NODISCARD_RESULT tgui::Button::Ptr WidgetBuilder::createSmallerButton(
+    const Label& label,
+    std::function<void(void)> onClick,
+    WidgetOptions options)
+{
+    auto&& button = tgui::Button::create(label);
+    button->onClick(onClick);
+    button->setTextSize(Sizers::getBaseFontSize());
+    button->setSize({ "90%", "80%" });
+    button->setPosition({ "5%", "10%" });
+    button->getRenderer()->setRoundedBorderRadius(10.f);
+    button->getRenderer()->setBackgroundColor(tgui::Color::Transparent);
 
     applyOptionsToWidget(options, button);
 

--- a/lib/src/input/InputDetector.cpp
+++ b/lib/src/input/InputDetector.cpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "input/InputDetector.hpp"
+
+constexpr const float AXIS_THRESHOLD_NEG = -80.f;
+constexpr const float AXIS_THRESHOLD_POS = 80.f;
+
+void InputDetector::update(const dgm::Time& time)
+{
+    initialDelay -= time.getDeltaTime();
+    if (initialDelay > 0.f) return;
+
+    if (runMode == RunMode::Idle) return;
+
+    if (sf::Keyboard::isKeyPressed(sf::Keyboard::Key::Escape))
+    {
+        runMode = RunMode::Idle;
+        cancel();
+    }
+    else if (runMode == RunMode::DetectingKmb)
+    {
+        if (tryKeyboard() == DetectionStatus::InputDetected
+            || tryMouse() == DetectionStatus::InputDetected)
+        {
+            runMode = RunMode::Idle;
+        }
+    }
+    else if (runMode == RunMode::DetectingGamepad)
+    {
+        if (tryGamepadAxis() == DetectionStatus::InputDetected
+            || tryGamepadButton() == DetectionStatus::InputDetected)
+        {
+            runMode = RunMode::Idle;
+        }
+    }
+}
+
+InputDetector::DetectionStatus InputDetector::tryGamepadAxis()
+{
+    for (auto&& axisIdx = 0; axisIdx < sf::Joystick::AxisCount; ++axisIdx)
+    {
+        const auto axis = static_cast<sf::Joystick::Axis>(axisIdx);
+        const auto position = sf::Joystick::getAxisPosition(0, axis);
+
+        if (position < AXIS_THRESHOLD_NEG)
+        {
+            reportGamepad(std::pair { axis, dgm::AxisHalf::Negative });
+            return DetectionStatus::InputDetected;
+        }
+        else if (position > AXIS_THRESHOLD_POS)
+        {
+            reportGamepad(std::pair { axis, dgm::AxisHalf::Positive });
+            return DetectionStatus::InputDetected;
+        }
+    }
+
+    return DetectionStatus::None;
+}
+
+InputDetector::DetectionStatus InputDetector::tryGamepadButton()
+{
+    for (auto&& btnIdx = 0u; btnIdx < sf::Joystick::ButtonCount; ++btnIdx)
+    {
+        const bool pressed = sf::Joystick::isButtonPressed(0, btnIdx);
+        if (pressed)
+        {
+            reportGamepad(GamepadButton { btnIdx });
+            return DetectionStatus::InputDetected;
+        }
+    }
+
+    return DetectionStatus::None;
+}
+
+InputDetector::DetectionStatus InputDetector::tryKeyboard()
+{
+    for (auto&& keyIdx = 0; keyIdx < sf::Keyboard::KeyCount; ++keyIdx)
+    {
+        const auto key = static_cast<sf::Keyboard::Key>(keyIdx);
+        const bool pressed = sf::Keyboard::isKeyPressed(key);
+
+        if (pressed)
+        {
+            reportKmb(key);
+            return DetectionStatus::InputDetected;
+        }
+    }
+
+    return DetectionStatus::None;
+}
+
+InputDetector::DetectionStatus InputDetector::tryMouse()
+{
+    for (auto&& mbtnIdx = 0; mbtnIdx < sf::Mouse::ButtonCount; ++mbtnIdx)
+    {
+        const auto mbtn = static_cast<sf::Mouse::Button>(mbtnIdx);
+        const bool pressed = sf::Mouse::isButtonPressed(mbtn);
+
+        if (pressed)
+        {
+            reportKmb(mbtn);
+            return DetectionStatus::InputDetected;
+        }
+    }
+
+    return DetectionStatus::None;
+}

--- a/tests/include/Helper.hpp
+++ b/tests/include/Helper.hpp
@@ -18,7 +18,8 @@ public:
 
     static DependencyContainer createDummyDependencies(dgm::Window& window)
     {
-        return DependencyContainer(window, ASSETS_PATH, Language::English);
+        return DependencyContainer(
+            window, ASSETS_PATH, Language::English, AppSettings {});
     }
 };
 


### PR DESCRIPTION
Adds a new section to Options that allows configuration of controls (looks like shit rn):
![image](https://github.com/user-attachments/assets/f580315a-2017-493f-967c-01b8042f192e)

Allows to configure Keyboard/Mouse bindings in one column and Gamepad ones in the other. Configuration is stored in `BindingsSettings` and `Input` is reconfigured each time as necessary.

**Bugs:**
* Tgui scrollable panel doesn't correctly compute height of the options content so the scrollbar doesn't work at all and the configuration can bleed out of screen on small screens.
* When "back" button is configured, the Options screen is immediately exited

**Tasks**
- [x] Deploy on Android, check for rendering errors (gamepads not yet supported in SFML)
- [x] Try to fix the back issue
- [x] Hide or fix scrollable panel for now