### PR TITLE
Feature: Android controller support

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,7 +1,7 @@
 include ( "${CMAKE_CURRENT_LIST_DIR}/add-catch.cmake" )
 
-set ( CXXOPTS_VERSION "3.2.1" )
-set ( NLOHMANN_VERSION "3.11.3" )
+set ( CXXOPTS_VERSION "3.3.1" )
+set ( NLOHMANN_VERSION "3.12.0" )
 set ( SFML_VERSION "3.0.0" )
 set ( DGM_LIB_VERSION "main" )
 set ( FSM_LIB_VERSION "2.1.1" )
@@ -14,7 +14,8 @@ CPMAddPackage("gh:jarro2783/cxxopts#v${CXXOPTS_VERSION}")
 CPMAddPackage("gh:nlohmann/json#v${NLOHMANN_VERSION}")
 
 set ( SFML_STATIC_LIBRARIES ${USE_SFML_TGUI_STATIC_LINKAGE} )
-CPMAddPackage("gh:SFML/SFML#${SFML_VERSION}")
+#CPMAddPackage("gh:SFML/SFML#${SFML_VERSION}")
+CPMAddPackage("gh:nerudaj/feature-android-joystick-support")
 
 set ( TGUI_BACKEND SFML_GRAPHICS )
 set ( TGUI_STATIC_LIBRARIES ${USE_SFML_TGUI_STATIC_LINKAGE} )

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -15,7 +15,7 @@ CPMAddPackage("gh:nlohmann/json#v${NLOHMANN_VERSION}")
 
 set ( SFML_STATIC_LIBRARIES ${USE_SFML_TGUI_STATIC_LINKAGE} )
 #CPMAddPackage("gh:SFML/SFML#${SFML_VERSION}")
-CPMAddPackage("gh:nerudaj/feature-android-joystick-support")
+CPMAddPackage("gh:nerudaj/SFML#feature-android-joystick-support")
 
 set ( TGUI_BACKEND SFML_GRAPHICS )
 set ( TGUI_STATIC_LIBRARIES ${USE_SFML_TGUI_STATIC_LINKAGE} )

--- a/lib/src/appstate/AppStateOptions.cpp
+++ b/lib/src/appstate/AppStateOptions.cpp
@@ -224,9 +224,12 @@ void AppStateOptions::buildBindingsOptionsLayout()
             const bool noGmp =
                 doesVariantContain(gamepadBinding, std::monostate {});
 
+            auto label = WidgetBuilder::createTextLabel(
+                inputKindMapper.inputKindToString(action));
+            label->getRenderer()->setPadding({ "5%", "0%", "0%", "0%" });
+
             tableBuilder.addRow({
-                WidgetBuilder::createTextLabel(
-                    inputKindMapper.inputKindToString(action)),
+                label,
                 buttonOrNothing(
                     WidgetBuilder::createSmallerButton(
                         std::visit(hwInputMapper, kmbBinding),

--- a/lib/src/input/Input.cpp
+++ b/lib/src/input/Input.cpp
@@ -80,7 +80,7 @@ Input::configureController(const BindingsSettings& settings)
                     [&](GamepadButton btn)
                     { controller.bindInput(action, btn.get()); },
                     [&](std::pair<sf::Joystick::Axis, dgm::AxisHalf> joy)
-                    { controller.bindInput(action, joy); },
+                    { controller.bindInput(action, joy.first, joy.second); },
                     [&](auto) {} },
                 gamepadBinding);
         }


### PR DESCRIPTION
* Bumping dependencies so not-yet-in-master version of SFML is used to support controllers on Android.
* Bumping nlohmann::json and cxxopts
* Adding padding to bindings setting table