### PR TITLE
Add cameras to dummy code

### DIFF
--- a/lib/include/appstate/AppStateGame.hpp
+++ b/lib/include/appstate/AppStateGame.hpp
@@ -19,7 +19,7 @@ public:
         , settings(settings)
         , scene(buildScene(dic.resmgr))
         , gameRulesEngine(gameEvents, scene, dic.input)
-        , renderingEngine(dic.resmgr, scene)
+        , renderingEngine(dic.resmgr, scene, sf::Vector2f(app.window.getSize()))
         , sound(dic.resmgr.get<sf::SoundBuffer>("land.wav"))
     {
         sound.setVolume(100.f);

--- a/lib/include/game/Scene.hpp
+++ b/lib/include/game/Scene.hpp
@@ -14,4 +14,5 @@ struct DummyEntity
 struct [[nodiscard]] Scene final
 {
     DummyEntity dummy;
+    sf::Vector2f groundPosition;
 };

--- a/lib/include/game/engine/RenderingEngine.hpp
+++ b/lib/include/game/engine/RenderingEngine.hpp
@@ -7,13 +7,23 @@
 class [[nodiscard]] RenderingEngine final
 {
 public:
-    RenderingEngine(dgm::ResourceManager& resmgr, Scene& scene) noexcept
+    RenderingEngine(
+        dgm::ResourceManager& resmgr,
+        Scene& scene,
+        const sf::Vector2f& resolution) noexcept
         : scene(scene)
-        , sprite(resmgr.get<sf::Texture>("mrman.png"))
+        , worldCamera(
+              createFullscreenCamera(resolution, INTERNAL_GAME_RESOLUTION))
+        , hudCamera(sf::FloatRect { { 0.f, 0.f }, { 1.f, 1.f } }, resolution)
         , text(resmgr.get<sf::Font>("ChunkFive-Regular.ttf"))
+        , sprite(resmgr.get<sf::Texture>("mrman.png"))
     {
         sprite.setOrigin(
             sf::Vector2f(scene.dummy.animation.getCurrentFrame().size) / 2.f);
+        ground.setPosition(scene.groundPosition);
+        ground.setFillColor(sf::Color(128, 192, 0));
+        ground.setSize({ INTERNAL_GAME_RESOLUTION.x,
+                         INTERNAL_GAME_RESOLUTION.y - scene.groundPosition.y });
     }
 
     RenderingEngine(RenderingEngine&&) = delete;
@@ -25,8 +35,30 @@ public:
     void draw(dgm::Window& window);
 
 private:
+    /**
+     * \brief Create fullscreen camera with a fixed resolution and aspect ratio
+     *
+     * When porting games to multiple systems / resolutions / aspect ratio, the
+     * renderer can show less / more than you need to. This function allows you
+     * to run the game at some fixed internal resolution, inserting black bars
+     * if the aspect ratio of the current device mismatches your desired aspect
+     * ratio.
+     */
+    static dgm::Camera createFullscreenCamera(
+        const sf::Vector2f& currentResolution,
+        const sf::Vector2f& desiredResolution);
+
+private:
+    const static inline auto INTERNAL_GAME_RESOLUTION =
+        sf::Vector2f { 1280.f, 720.f };
+
     Scene& scene;
-    sf::Sprite sprite;
+    dgm::Camera worldCamera;
+    dgm::Camera hudCamera;
+
     FpsCounter fpsCounter;
     sf::Text text;
+
+    sf::Sprite sprite;
+    sf::RectangleShape ground;
 };

--- a/lib/src/appstate/AppStateGame.cpp
+++ b/lib/src/appstate/AppStateGame.cpp
@@ -56,5 +56,6 @@ Scene AppStateGame::buildScene(const dgm::ResourceManager& resmgr)
                 .body = dgm::Rect({ 100.f, 100.f }, { 32.f, 60.f }),
                 .animation = std::move(animation),
             },
+        .groundPosition = { 0.f, 400.f },
     };
 }

--- a/lib/src/game/engine/GameRulesEngine.cpp
+++ b/lib/src/game/engine/GameRulesEngine.cpp
@@ -62,7 +62,6 @@ void GameRulesEngine::updateDummy(DummyEntity& dummy, const float deltaTime)
     const float GRAVITY = 256.f;
     const float MAX_FALL_SPEED = 256.f;
     const float SPEED = 128.f;
-    const float VERTICAL_LIMIT = 400.f;
 
     // Apply horizontal impulse
     const float airControlNerf = dummy.forward.y == 0.f ? 1.f : 0.75f;
@@ -83,11 +82,11 @@ void GameRulesEngine::updateDummy(DummyEntity& dummy, const float deltaTime)
         dummy.forward.x < 0.f || dummy.forward.x == 0.f && dummy.facingLeft;
 
     auto pos = dummy.body.getPosition();
-    if (pos.y + dummy.body.getSize().y > VERTICAL_LIMIT)
+    if (pos.y + dummy.body.getSize().y > scene.groundPosition.y)
     {
         dummy.forward.y = 0.f;
         dummy.body.setPosition(
-            { pos.x, VERTICAL_LIMIT - dummy.body.getSize().y });
+            { pos.x, scene.groundPosition.y - dummy.body.getSize().y });
     }
 }
 

--- a/lib/src/game/engine/RenderingEngine.cpp
+++ b/lib/src/game/engine/RenderingEngine.cpp
@@ -7,13 +7,48 @@ void RenderingEngine::update(const dgm::Time& time)
 
 void RenderingEngine::draw(dgm::Window& window)
 {
+    // Render the game world
+    window.setViewFromCamera(worldCamera);
+
     sprite.setTextureRect(scene.dummy.animation.getCurrentFrame());
     sprite.setPosition(scene.dummy.body.getCenter());
     sprite.setScale({ scene.dummy.facingLeft ? -1.f : 1.f, 1.f });
 
     scene.dummy.body.debugRender(window); // rendering hitbox
+    window.draw(ground);
     window.draw(sprite);
+
+    // Render everything hud-related
+    window.setViewFromCamera(hudCamera);
 
     text.setString(fpsCounter.getText());
     window.draw(text);
+}
+
+dgm::Camera RenderingEngine::createFullscreenCamera(
+    const sf::Vector2f& currentResolution,
+    const sf::Vector2f& desiredResolution)
+{
+    auto&& viewport = sf::FloatRect {
+        { 0.f, 0.f },
+        { 1.f, 1.f },
+    };
+
+    const auto& desiredAspectRatio = desiredResolution.x / desiredResolution.y;
+    const auto& currentAspectRatio = currentResolution.x / currentResolution.y;
+
+    if (currentAspectRatio > desiredAspectRatio)
+    {
+        // Narrow desired into wider current
+        viewport.size.x = desiredResolution.x / currentResolution.x;
+        viewport.position.x = (1.f - viewport.size.x) / 2.f;
+    }
+    else if (currentAspectRatio < desiredAspectRatio)
+    {
+        // Wider desired into narrower current
+        viewport.size.y = desiredResolution.y / currentResolution.y;
+        viewport.position.y = (1.f - viewport.size.y) / 2.f;
+    }
+
+    return dgm::Camera(viewport, sf::Vector2f(desiredResolution));
 }

--- a/lib/src/game/engine/RenderingEngine.cpp
+++ b/lib/src/game/engine/RenderingEngine.cpp
@@ -34,19 +34,19 @@ dgm::Camera RenderingEngine::createFullscreenCamera(
         { 1.f, 1.f },
     };
 
-    const auto& desiredAspectRatio = desiredResolution.x / desiredResolution.y;
-    const auto& currentAspectRatio = currentResolution.x / currentResolution.y;
+    const auto&& desiredAspectRatio = desiredResolution.x / desiredResolution.y;
+    const auto&& currentAspectRatio = currentResolution.x / currentResolution.y;
 
     if (currentAspectRatio > desiredAspectRatio)
     {
         // Narrow desired into wider current
-        viewport.size.x = desiredResolution.x / currentResolution.x;
+        viewport.size.x = desiredResolution.y / currentResolution.y;
         viewport.position.x = (1.f - viewport.size.x) / 2.f;
     }
     else if (currentAspectRatio < desiredAspectRatio)
     {
         // Wider desired into narrower current
-        viewport.size.y = desiredResolution.y / currentResolution.y;
+        viewport.size.y = desiredResolution.x / currentResolution.x;
         viewport.position.y = (1.f - viewport.size.y) / 2.f;
     }
 

--- a/lib/src/input/Input.cpp
+++ b/lib/src/input/Input.cpp
@@ -13,7 +13,7 @@ void Input::forceRelease(InputKind action)
 
 float Input::getHorizontalVelocity() const
 {
-    return controller.readAnalog(InputKind::Left)
+    return -controller.readAnalog(InputKind::Left)
            + controller.readAnalog(InputKind::Right);
 }
 


### PR DESCRIPTION
* Added world / hud cameras - essential for any game with scrolling
* World camera runs on internal HD resolution while HUD camera runs on system resolution
    * Therefore, world camera will behave the same on all devices