### PR TITLE
Android: Allow the app to render into camera cutout area

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,11 @@ if ( ${BUILD_ANDROID} )
         "${CMAKE_CURRENT_SOURCE_DIR}/android/infiles/AndroidManifest.xml.in"
         "${CMAKE_CURRENT_BINARY_DIR}/app/src/main/AndroidManifest.xml"
     )
+
+    configure_file (
+        "${CMAKE_CURRENT_SOURCE_DIR}/android/infiles/styles.xml.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/app/src/main/res/values/styles.xml"
+    )
     
     install (
         FILES

--- a/android/infiles/AndroidManifest.xml.in
+++ b/android/infiles/AndroidManifest.xml.in
@@ -6,7 +6,8 @@
     <application android:label="@THE_PROJECT_NAME@"
                  android:icon="@drawable/app_logo"
                  android:hasCode="false"
-                 android:allowBackup="true">
+                 android:allowBackup="true"
+                 android:theme="@style/AppTheme">
 
     <activity android:name="android.app.NativeActivity"
               android:icon="@drawable/app_logo"

--- a/android/infiles/styles.xml.in
+++ b/android/infiles/styles.xml.in
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="@android:style/Theme.NoTitleBar.Fullscreen">
+        <!-- Allow content in the display cutout area -->
+        <item name="android:windowLayoutInDisplayCutoutMode">@ANDROID_WINDOW_LAYOUT_IN_DISPLAY_CUTOUT_MODE@</item>
+
+        <!-- Make the app fullscreen so the cutout is actually used -->
+        <item name="android:windowFullscreen">true</item>
+
+        <!-- Ensure system bars overlay instead of resizing the window -->
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:fitsSystemWindows">false</item>
+    </style>
+</resources>

--- a/cmake/vars.cmake
+++ b/cmake/vars.cmake
@@ -18,3 +18,6 @@ set ( ANDROID_NDK_VERSION "27.0.12077973" )
 set ( ANDROID_MIN_SDK "22" )
 set ( ANDROID_TARGET_SDK "33" )
 set ( ANDROID_ENFORCED_ORIENTATION "landscape" ) # landscape | portrait
+
+## shortEdges mean that the app will render into camera cutout area
+set ( ANDROID_WINDOW_LAYOUT_IN_DISPLAY_CUTOUT_MODE "never" ) # shortEdges | never

--- a/cmake/vars.cmake
+++ b/cmake/vars.cmake
@@ -15,7 +15,7 @@ set ( ANDROID_ORG "org.nerudaj.${PROJECT_NAME_LOWERCASE}" )
 set ( ANDROID_NATIVE_LIB_NAME "cppcore" )
 set ( ANDROID_ARCH_ABI "arm64-v8a" )
 set ( ANDROID_NDK_VERSION "27.0.12077973" )
-set ( ANDROID_MIN_SDK "22" )
+set ( ANDROID_MIN_SDK "27" ) # Android 8.1 and newer (2017 onwards)
 set ( ANDROID_TARGET_SDK "33" )
 set ( ANDROID_ENFORCED_ORIENTATION "landscape" ) # landscape | portrait
 

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -1,0 +1,9 @@
+# Android Help
+
+## TouchController poorly registers inputs/inputs are offset from real touch location
+
+This happens when the application is not allowed to render into camera cutout area. SFML reports Window size equal to your phone resolution, but the OS is forcing it to render in a lower area.
+
+I haven't found any JNI/NDK API to detect this behavior, so instead my recommended fix is to configure the application to render into cutout area, so the dimensions match.
+
+To do so, make sure that `/cmake/vars.cmake` variable called `ANDROID_WINDOW_LAYOUT_IN_DISPLAY_CUTOUT_MODE` is set to `shortEdges`.

--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -3,3 +3,4 @@
 * [Application Icons](AppIcons.md)
 * [Signing APKs](ApkSigning.md)
 * [UI Guide](Ui.md)
+* [Android Help](Android.md)


### PR DESCRIPTION
- Also bumping min SDK to 27 (Android 8.1 and newer)